### PR TITLE
Fix target links

### DIFF
--- a/src/app/page.md
+++ b/src/app/page.md
@@ -17,7 +17,7 @@ Welcome to Rails AI! This is a free, open source book that aims to make it as qu
 
 ## What's this book about?
 
-From the start of the [ruby-openai](https://github.com) project in 2020, my goal was for a junior developer to be able to the correct section of the README, find a working example of the code they need, copy paste that exact code into their project and it would just work.
+From the start of the [ruby-openai](https://github.com/alexrudall/ruby-openai) project in 2020, my goal was for a junior developer to be able to the correct section of the README, find a working example of the code they need, copy paste that exact code into their project and it would just work.
 
 I believe that this experience is also valuable no matter how senior you are - documentation should be Simple, Clear, Up-to-date, Copy-Pasteable and Runnable.
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -56,7 +56,7 @@ function Header() {
       </div>
       <div className="relative flex basis-0 justify-end gap-6 sm:gap-8 md:flex-grow">
         <ThemeSelector className="relative z-10" />
-        <Link href="https://github.com/alexrudall/railsai" className="group" aria-label="GitHub">
+        <Link href="https://github.com/alexrudall/railsai" className="group" aria-label="GitHub" target="_blank" rel="noopener noreferrer">
           <GitHubIcon className="h-6 w-6 fill-slate-400 group-hover:fill-slate-500 dark:group-hover:fill-slate-300" />
         </Link>
       </div>


### PR DESCRIPTION
@alexrudall I found that the GitHub logo link didn't have the `target="_blank"` attribute, so I added it along with the `noopener` attribute [based on this](https://github.com/standard/standard/issues/1367).

Also, I corrected the first link to the `ruby-openai` gem, which was not pointing to the right URL.